### PR TITLE
Revert "fix: fixed failing queries using aggregation pipeline (#26132)"

### DIFF
--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/BaseRepositoryImpl.java
@@ -161,9 +161,7 @@ public class BaseRepositoryImpl<T extends BaseDomain, ID extends Serializable>
                 .flatMapMany(principal -> {
                     Query query = new Query(notDeleted());
                     return mongoOperations.find(
-                            query.cursorBatchSize(10000),
-                            entityInformation.getJavaType(),
-                            entityInformation.getCollectionName());
+                            query, entityInformation.getJavaType(), entityInformation.getCollectionName());
                 });
     }
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewActionRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomNewActionRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
@@ -15,8 +14,7 @@ public class CustomNewActionRepositoryImpl extends CustomNewActionRepositoryCEIm
     public CustomNewActionRepositoryImpl(
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper,
-            MongoTemplate mongoTemplate) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper, mongoTemplate);
+            CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepositoryImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/CustomNewPageRepositoryImpl.java
@@ -2,7 +2,6 @@ package com.appsmith.server.repositories;
 
 import com.appsmith.server.repositories.ce.CustomNewPageRepositoryCEImpl;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.stereotype.Component;
@@ -14,8 +13,7 @@ public class CustomNewPageRepositoryImpl extends CustomNewPageRepositoryCEImpl i
     public CustomNewPageRepositoryImpl(
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper,
-            MongoTemplate mongoTemplate) {
-        super(mongoOperations, mongoConverter, cacheableRepositoryHelper, mongoTemplate);
+            CacheableRepositoryHelper cacheableRepositoryHelper) {
+        super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/BaseAppsmithRepositoryCEImpl.java
@@ -22,7 +22,6 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.data.mongodb.core.query.Update;
 import org.springframework.data.mongodb.core.query.UpdateDefinition;
-import org.springframework.data.mongodb.repository.Meta;
 import org.springframework.security.core.context.ReactiveSecurityContextHolder;
 import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
@@ -167,7 +166,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
 
             return mongoOperations
                     .query(this.genericDomain)
-                    .matching(query.cursorBatchSize(10000))
+                    .matching(query)
                     .one()
                     .flatMap(obj -> setUserPermissionsInObject(obj, permissionGroups));
         });
@@ -332,7 +331,6 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
         });
     }
 
-    @Meta(cursorBatchSize = 10000)
     protected Mono<T> queryOne(
             List<Criteria> criterias, List<String> projectionFieldNames, Optional<AclPermission> permission) {
         Mono<Set<String>> permissionGroupsMono = getCurrentUserPermissionGroupsIfRequired(permission);
@@ -541,7 +539,7 @@ public abstract class BaseAppsmithRepositoryCEImpl<T extends BaseDomain> {
         sortOptional.ifPresent(sort -> query.with(sort));
         return mongoOperations
                 .query(this.genericDomain)
-                .matching(query.cursorBatchSize(10000))
+                .matching(query)
                 .all()
                 .flatMap(obj -> setUserPermissionsInObject(obj, permissionGroups));
     }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewActionRepositoryCE.java
@@ -78,7 +78,7 @@ public interface CustomNewActionRepositoryCE extends AppsmithRepository<NewActio
 
     Mono<List<BulkWriteResult>> bulkUpdate(List<NewAction> newActions);
 
-    Mono<List<BulkWriteResult>> publishActions(String applicationId, AclPermission permission);
+    Mono<UpdateResult> publishActions(String applicationId, AclPermission permission);
 
     Mono<UpdateResult> archiveDeletedUnpublishedActions(String applicationId, AclPermission permission);
 

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCE.java
@@ -3,7 +3,7 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.server.acl.AclPermission;
 import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.repositories.AppsmithRepository;
-import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.result.UpdateResult;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -43,7 +43,5 @@ public interface CustomNewPageRepositoryCE extends AppsmithRepository<NewPage> {
     Mono<NewPage> findByGitSyncIdAndDefaultApplicationId(
             String defaultApplicationId, String gitSyncId, Optional<AclPermission> permission);
 
-    Mono<List<BulkWriteResult>> publishPages(Collection<String> pageIds, AclPermission permission);
-
-    Mono<List<BulkWriteResult>> bulkUpdate(List<NewPage> newPages);
+    Mono<UpdateResult> publishPages(Collection<String> pageIds, AclPermission permission);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/CustomNewPageRepositoryCEImpl.java
@@ -9,32 +9,20 @@ import com.appsmith.server.domains.QNewPage;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.repositories.BaseAppsmithRepositoryImpl;
 import com.appsmith.server.repositories.CacheableRepositoryHelper;
-import com.mongodb.bulk.BulkWriteResult;
-import com.mongodb.client.model.UpdateOneModel;
-import com.mongodb.client.model.WriteModel;
+import com.mongodb.client.result.UpdateResult;
 import lombok.extern.slf4j.Slf4j;
-import org.bson.Document;
-import org.bson.types.ObjectId;
-import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.ReactiveMongoOperations;
-import org.springframework.data.mongodb.core.aggregation.Aggregation;
-import org.springframework.data.mongodb.core.aggregation.AggregationOperation;
-import org.springframework.data.mongodb.core.aggregation.AggregationResults;
-import org.springframework.data.mongodb.core.aggregation.Fields;
+import org.springframework.data.mongodb.core.aggregation.AggregationUpdate;
 import org.springframework.data.mongodb.core.convert.MongoConverter;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.util.CollectionUtils;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 import static org.springframework.data.mongodb.core.query.Criteria.where;
 
@@ -42,15 +30,11 @@ import static org.springframework.data.mongodb.core.query.Criteria.where;
 public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<NewPage>
         implements CustomNewPageRepositoryCE {
 
-    private final MongoTemplate mongoTemplate;
-
     public CustomNewPageRepositoryCEImpl(
             ReactiveMongoOperations mongoOperations,
             MongoConverter mongoConverter,
-            CacheableRepositoryHelper cacheableRepositoryHelper,
-            MongoTemplate mongoTemplate) {
+            CacheableRepositoryHelper cacheableRepositoryHelper) {
         super(mongoOperations, mongoConverter, cacheableRepositoryHelper);
-        this.mongoTemplate = mongoTemplate;
     }
 
     @Override
@@ -267,55 +251,14 @@ public class CustomNewPageRepositoryCEImpl extends BaseAppsmithRepositoryImpl<Ne
     }
 
     @Override
-    public Mono<List<BulkWriteResult>> publishPages(Collection<String> pageIds, AclPermission permission) {
+    public Mono<UpdateResult> publishPages(Collection<String> pageIds, AclPermission permission) {
         Criteria applicationIdCriteria = where(fieldName(QNewPage.newPage.id)).in(pageIds);
+        // using aggregation update instead of regular update here
+        // it's required to set a field to a value of another field from the same domain
+        AggregationUpdate aggregationUpdate = AggregationUpdate.update()
+                .set(fieldName(QNewPage.newPage.publishedPage))
+                .toValue("$" + fieldName(QNewPage.newPage.unpublishedPage));
 
-        Mono<Set<String>> permissionGroupsMono =
-                getCurrentUserPermissionGroupsIfRequired(Optional.ofNullable(permission));
-
-        return permissionGroupsMono.flatMap(permissionGroups -> {
-            AggregationOperation matchAggregationWithPermission = null;
-            if (permission == null) {
-                matchAggregationWithPermission = Aggregation.match(new Criteria().andOperator(notDeleted()));
-            } else {
-                matchAggregationWithPermission = Aggregation.match(
-                        new Criteria().andOperator(notDeleted(), userAcl(permissionGroups, permission)));
-            }
-            AggregationOperation matchAggregation = Aggregation.match(applicationIdCriteria);
-            AggregationOperation wholeProjection = Aggregation.project(NewPage.class);
-            AggregationOperation addFieldsOperation = Aggregation.addFields()
-                    .addField(fieldName(QNewPage.newPage.publishedPage))
-                    .withValueOf(Fields.field(fieldName(QNewPage.newPage.unpublishedPage)))
-                    .build();
-            Aggregation combinedAggregation = Aggregation.newAggregation(
-                    matchAggregation, matchAggregationWithPermission, wholeProjection, addFieldsOperation);
-            AggregationResults<NewPage> updatedResults =
-                    mongoTemplate.aggregate(combinedAggregation, NewPage.class, NewPage.class);
-            return bulkUpdate(updatedResults.getMappedResults());
-        });
-    }
-
-    @Override
-    public Mono<List<BulkWriteResult>> bulkUpdate(List<NewPage> newPages) {
-        if (CollectionUtils.isEmpty(newPages)) {
-            return Mono.just(Collections.emptyList());
-        }
-
-        // convert the list of new pages to a list of DBObjects
-        List<WriteModel<Document>> dbObjects = newPages.stream()
-                .map(newPage -> {
-                    assert newPage.getId() != null;
-                    Document document = new Document();
-                    mongoOperations.getConverter().write(newPage, document);
-                    document.remove("_id");
-                    return (WriteModel<Document>) new UpdateOneModel<Document>(
-                            new Document("_id", new ObjectId(newPage.getId())), new Document("$set", document));
-                })
-                .collect(Collectors.toList());
-
-        return mongoOperations
-                .getCollection(mongoOperations.getCollectionName(NewPage.class))
-                .flatMapMany(documentMongoCollection -> documentMongoCollection.bulkWrite(dbObjects))
-                .collectList();
+        return updateByCriteria(List.of(applicationIdCriteria), aggregationUpdate, permission);
     }
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/NewActionRepositoryCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/repositories/ce/NewActionRepositoryCE.java
@@ -3,17 +3,12 @@ package com.appsmith.server.repositories.ce;
 import com.appsmith.server.domains.NewAction;
 import com.appsmith.server.repositories.BaseRepository;
 import com.appsmith.server.repositories.CustomNewActionRepository;
-import org.springframework.data.mongodb.repository.Meta;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
 public interface NewActionRepositoryCE extends BaseRepository<NewAction, String>, CustomNewActionRepository {
 
-    @Meta(cursorBatchSize = 10000)
     Flux<NewAction> findByApplicationId(String applicationId);
-
-    @Meta(cursorBatchSize = 10000)
-    Flux<NewAction> findAllByIdIn(Iterable<String> ids);
 
     Mono<Long> countByDeletedAtNull();
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/ApplicationPageServiceCEImpl.java
@@ -50,7 +50,6 @@ import com.appsmith.server.solutions.ApplicationPermission;
 import com.appsmith.server.solutions.PagePermission;
 import com.appsmith.server.solutions.WorkspacePermission;
 import com.google.common.base.Strings;
-import com.mongodb.bulk.BulkWriteResult;
 import com.mongodb.client.result.UpdateResult;
 import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
@@ -1135,7 +1134,7 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                     if (isPublishedManually) {
                         application.setLastDeployedAt(Instant.now());
                     }
-                    Mono<List<BulkWriteResult>> publishPagesMono =
+                    Mono<UpdateResult> publishPagesMono =
                             newPageService.publishPages(editedPageIds, pagePermission.getEditPermission());
 
                     // Archive the deleted pages and save the application changes and then return the pages so that
@@ -1145,7 +1144,7 @@ public class ApplicationPageServiceCEImpl implements ApplicationPageServiceCE {
                 })
                 .cache(); // caching as we'll need this to send analytics attributes after publishing the app
 
-        Mono<List<BulkWriteResult>> publishActionsMono =
+        Mono<UpdateResult> publishActionsMono =
                 newActionService.publishActions(applicationId, actionPermission.getEditPermission());
 
         // this is a map of pluginType to count of actions for that pluginType, required for analytics

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCE.java
@@ -14,7 +14,7 @@ import com.appsmith.server.dtos.ce.ImportActionResultDTO;
 import com.appsmith.server.dtos.ce.ImportedActionAndCollectionMapsDTO;
 import com.appsmith.server.helpers.ce.ImportApplicationPermissionProvider;
 import com.appsmith.server.services.CrudService;
-import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.result.UpdateResult;
 import org.springframework.data.domain.Sort;
 import org.springframework.util.MultiValueMap;
 import reactor.core.publisher.Flux;
@@ -134,7 +134,7 @@ public interface NewActionServiceCE extends CrudService<NewAction, String> {
             ImportActionCollectionResultDTO importActionCollectionResultDTO,
             ImportActionResultDTO importActionResultDTO);
 
-    Mono<List<BulkWriteResult>> publishActions(String applicationId, AclPermission permission);
+    Mono<UpdateResult> publishActions(String applicationId, AclPermission permission);
 
     Flux<PluginTypeAndCountDTO> countActionsByPluginType(String applicationId);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewActionServiceCEImpl.java
@@ -53,7 +53,7 @@ import com.appsmith.server.solutions.ApplicationPermission;
 import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.PagePermission;
 import com.appsmith.server.solutions.PolicySolution;
-import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.result.UpdateResult;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
@@ -663,7 +663,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
 
     @Override
     public Flux<NewAction> findAllById(Iterable<String> id) {
-        return repository.findAllByIdIn(id).flatMap(this::sanitizeAction);
+        return repository.findAllById(id).flatMap(this::sanitizeAction);
     }
 
     @Override
@@ -1907,7 +1907,7 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
         }
 
         return repository
-                .findAllByIdIn(actionIds)
+                .findAllById(actionIds)
                 .map(newAction -> {
                     // Update collectionId and defaultCollectionIds in actionDTOs
                     ActionDTO unpublishedAction = newAction.getUnpublishedAction();
@@ -1959,13 +1959,12 @@ public class NewActionServiceCEImpl extends BaseService<NewActionRepository, New
      * This method is used to publish actions of an application. It does two things:
      * 1. it deletes actions which are deleted from the edit mode.
      * 2. It updates actions in bulk by setting publishedAction=unpublishedAction
-     *
      * @param applicationId
      * @param permission
      * @return
      */
     @Override
-    public Mono<List<BulkWriteResult>> publishActions(String applicationId, AclPermission permission) {
+    public Mono<UpdateResult> publishActions(String applicationId, AclPermission permission) {
         // delete the actions that were deleted in edit mode
         return repository
                 .archiveDeletedUnpublishedActions(applicationId, permission)

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCE.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCE.java
@@ -7,7 +7,7 @@ import com.appsmith.server.domains.NewPage;
 import com.appsmith.server.dtos.ApplicationPagesDTO;
 import com.appsmith.server.dtos.PageDTO;
 import com.appsmith.server.services.CrudService;
-import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.result.UpdateResult;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
@@ -93,5 +93,5 @@ public interface NewPageServiceCE extends CrudService<NewPage, String> {
 
     Flux<NewPage> findPageSlugsByApplicationIds(List<String> applicationIds, AclPermission aclPermission);
 
-    Mono<List<BulkWriteResult>> publishPages(Collection<String> pageIds, AclPermission permission);
+    Mono<UpdateResult> publishPages(Collection<String> pageIds, AclPermission permission);
 }

--- a/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
+++ b/app/server/appsmith-server/src/main/java/com/appsmith/server/services/ce/NewPageServiceCEImpl.java
@@ -23,7 +23,7 @@ import com.appsmith.server.services.BaseService;
 import com.appsmith.server.services.UserDataService;
 import com.appsmith.server.solutions.ApplicationPermission;
 import com.appsmith.server.solutions.PagePermission;
-import com.mongodb.bulk.BulkWriteResult;
+import com.mongodb.client.result.UpdateResult;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
 import net.minidev.json.JSONObject;
@@ -692,7 +692,7 @@ public class NewPageServiceCEImpl extends BaseService<NewPageRepository, NewPage
     }
 
     @Override
-    public Mono<List<BulkWriteResult>> publishPages(Collection<String> pageIds, AclPermission permission) {
+    public Mono<UpdateResult> publishPages(Collection<String> pageIds, AclPermission permission) {
         return repository.publishPages(pageIds, permission);
     }
 }

--- a/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/NewActionServiceUnitTest.java
+++ b/app/server/appsmith-server/src/test/java/com/appsmith/server/services/ce/NewActionServiceUnitTest.java
@@ -23,6 +23,7 @@ import com.appsmith.server.solutions.ApplicationPermission;
 import com.appsmith.server.solutions.DatasourcePermission;
 import com.appsmith.server.solutions.PagePermission;
 import com.appsmith.server.solutions.PolicySolution;
+import com.mongodb.client.result.UpdateResult;
 import io.micrometer.observation.ObservationRegistry;
 import jakarta.validation.Validator;
 import lombok.extern.slf4j.Slf4j;
@@ -37,8 +38,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import reactor.core.publisher.Mono;
 import reactor.core.scheduler.Scheduler;
 import reactor.test.StepVerifier;
-
-import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -200,8 +199,9 @@ public class NewActionServiceUnitTest {
     @Test
     public void testPublishActionArchivesAndPublishesActions() {
         String applicationId = "dummy-application-id";
-        List updateResult = Mockito.mock(List.class);
-        Mockito.when(updateResult.size()).thenReturn(10);
+        UpdateResult updateResult = Mockito.mock(UpdateResult.class);
+        Mockito.when(updateResult.getModifiedCount()).thenReturn(10L);
+        Mockito.when(updateResult.getMatchedCount()).thenReturn(5L);
 
         Mockito.when(newActionRepository.archiveDeletedUnpublishedActions(
                         applicationId, actionPermission.getEditPermission()))
@@ -212,7 +212,8 @@ public class NewActionServiceUnitTest {
 
         StepVerifier.create(newActionService.publishActions(applicationId, actionPermission.getEditPermission()))
                 .assertNext(updateResult1 -> {
-                    assertEquals(10, updateResult1.size());
+                    assertEquals(10L, updateResult1.getModifiedCount());
+                    assertEquals(5L, updateResult1.getMatchedCount());
                 })
                 .verifyComplete();
     }


### PR DESCRIPTION
This reverts commit 66d5027126523fb73cb14ce1336b171a85f8db37.

## Description
> [!TIP]  
> _Add a TL;DR when the description is longer than 500 words or extremely technical (helps the content, marketing, and DevRel team)._
>
> _Please also include relevant motivation and context. List any dependencies that are required for this change. Add links to Notion, Figma or any other documents that might be relevant to the PR._


Fixes #`Issue Number`  
_or_  
Fixes `Issue URL`
> [!WARNING]  
> _If no issue exists, please create an issue first, and check with the maintainers if the issue is valid._

## Automation

/ok-to-test tags=""

### :mag: Cypress test results
<!-- This is an auto-generated comment: Cypress test results  -->
> [!CAUTION]  
> If you modify the content in this section, you are likely to disrupt the CI result for your PR.

<!-- end of auto-generated comment: Cypress test results  -->


## Communication
Should the DevRel and Marketing teams inform users about this change?
- [ ] Yes
- [ ] No


<!-- greptile_comment -->

## Greptile Summary

Based on the provided information, I'll create a comprehensive summary of this pull request that reverts changes related to MongoDB query implementations.

This reversion of PR #26132 makes significant changes to MongoDB query handling across multiple repository and service layers:

- Removes MongoDB cursor batch size configuration (10000) from query operations
- Switches from bulk write operations back to individual updates for publishing actions/pages
- Reverts from `BulkWriteResult` to `UpdateResult` for operation feedback
- Removes `MongoTemplate` dependencies from several repository implementations
- Simplifies aggregation pipeline usage in favor of basic aggregation updates

Key Impact Points:
- Performance may be affected when dealing with large result sets due to removal of cursor batch size optimization
- Publishing operations now use simpler individual updates instead of atomic bulk operations
- Less granular error reporting due to switch from `BulkWriteResult` to `UpdateResult`
- Query execution patterns revert to pre-aggregation pipeline implementations

This appears to be addressing compatibility issues with DocumentDB, though care should be taken to monitor query performance and data integrity after these changes.

<!-- /greptile_comment -->